### PR TITLE
Change homepage of pubspec.yaml to GitHub URL

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: twitter_login
 description: Flutter Twitter Login Plugin. Library for login with Twitter APIs OAuth service
 version: 1.0.1
-homepage: https://twitter.com/0maru_dev
+homepage: https://github.com/0maru/twitter_login
 
 environment:
   sdk: ">=2.7.0 <3.0.0"


### PR DESCRIPTION
It is common practice to set the the repository URL to `homepage` of pubspec.yaml.