### PR TITLE
Fix the exception when the user closes the browser

### DIFF
--- a/lib/src/twitter_login.dart
+++ b/lib/src/twitter_login.dart
@@ -82,6 +82,10 @@ class TwitterLogin {
       } else {
         throw UnsupportedError('Not supported by this os.');
       }
+      // The user closed the browser
+      if (resultURI == null) {
+        throw CanceldByUserException();
+      }
       final queries = Uri.splitQueryString(Uri.parse(resultURI).query);
       if (queries['error'] != null) {
         throw Exception('Error Response: ${queries['error']}');


### PR DESCRIPTION
Thanks for the great plugin!
Implementation and Twitter login is now possible.
However, there was one problem in my environment: 1.

1. start Twitter login and the browser opens the application authentication screen.
2. close the browser by pressing the "Cancel" button on iOS or the "X" button on Android.
3. a TwitterLoginStatus.error is returned.

For more details, a `NoSuchMethodError` seems to have been raised.
The `NoSuchMethodError` is raised.

```
NoSuchMethodError (NoSuchMethodError: The getter 'length' was called on null.
Receiver: null.
Tried calling: length)
````

An exception is likely to be raised by the following because the `resultURI` is `null` when the browser is closed.
final queries = Uri.splitQueryString(Uri.parse(resultURI).query)`

I apologize if this is not a problem with the plugin, but a specific problem with my environment or implementation.

Thank you for your help.

---

0maruさん、素晴らしいプラグインをありがとうございます！
実装し、Twitterログインができるようになりました。
しかし、僕の環境では一つ問題がありました。

1. Twitterログインを開始し、アプリケーション認証画面をブラウザが開きます。
2. iOSでは「キャンセル」、Androidでは「×」ボタンを押してブラウザを閉じる
3. TwitterLoginStatus.error が返されます。

詳しくは、 `NoSuchMethodError` が発生しているようです。
```
NoSuchMethodError (NoSuchMethodError: The getter 'length' was called on null.
Receiver: null
Tried calling: length)
```

ブラウザを閉じたときに `resultURI` が `null` なため、以下で例外が発生していると思われます。
`final queries = Uri.splitQueryString(Uri.parse(resultURI).query)`

このプラグインの問題ではなく、僕の環境や実装による個別の問題でしたら申し訳ありません。

よろしくお願いいたします。