### PR TITLE
Change user id to int type

### DIFF
--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -5,7 +5,7 @@ class User {
   /// The unique identifier of this user.
   ///
   /// Use this to programmatically retrieve information about a specific Twitter user.
-  final String _id;
+  final int _id;
 
   /// user email address
   final String _email;
@@ -22,7 +22,7 @@ class User {
   /// The unique identifier of this user.
   ///
   /// Use this to programmatically retrieve information about a specific Twitter user.
-  String get id => _id;
+  int get id => _id;
 
   /// user email address
   ///


### PR DESCRIPTION
Fixed the type of the id field of User Entity from string to int.
If the type is still string, the following error will be thrown.
```
type 'int' is not a subtype of type 'String'
```