### PR TITLE
Fix browser suspend when custom tabs is unavailable

### DIFF
--- a/android/src/main/kotlin/com/maru/twitter_login/chrome_custom_tabs/ChromeSafariBrowserManager.java
+++ b/android/src/main/kotlin/com/maru/twitter_login/chrome_custom_tabs/ChromeSafariBrowserManager.java
@@ -49,6 +49,7 @@ public class ChromeSafariBrowserManager implements MethodChannel.MethodCallHandl
     public void open(Activity activity, String id, String url, MethodChannel.Result result) {
         if (!CustomTabActivityHelper.isAvailable(activity)) {
             result.success(false);
+            return;
         }
 
         Bundle extras = new Bundle();

--- a/lib/src/auth_browser.dart
+++ b/lib/src/auth_browser.dart
@@ -57,16 +57,16 @@ class AuthBrowser {
   }
 
   ///　Open a web browser and log in to your Twitter account.
-  Future<void> open(String url, String scheme) async {
+  Future<bool> open(String url, String scheme) async {
     if (Platform.isIOS) {
-      return;
+      return false;
     }
     if (_isOpen) {
       throw PlatformException(code: 'AuthBrowser is opened.');
     }
 
     _isOpen = true;
-    await _channel.invokeMethod('open', {
+    return await _channel.invokeMethod('open', {
       'url': url,
       'redirectURL': scheme,
       'id': id,

--- a/lib/src/auth_browser.dart
+++ b/lib/src/auth_browser.dart
@@ -65,11 +65,14 @@ class AuthBrowser {
       throw PlatformException(code: 'AuthBrowser is opened.');
     }
 
-    _isOpen = true;
-    return await _channel.invokeMethod('open', {
+    final available = await _channel.invokeMethod('open', {
       'url': url,
       'redirectURL': scheme,
       'id': id,
     });
+    if (available) {
+      _isOpen = true;
+    }
+    return available;
   }
 }

--- a/lib/src/twitter_login.dart
+++ b/lib/src/twitter_login.dart
@@ -34,7 +34,8 @@ class TwitterLogin {
 
   static const _channel = const MethodChannel('twitter_login');
   static final _eventChannel = EventChannel('twitter_login/event');
-  static final Stream<dynamic> _eventStream = _eventChannel.receiveBroadcastStream();
+  static final Stream<dynamic> _eventStream =
+      _eventChannel.receiveBroadcastStream();
 
   /// constructor
   TwitterLogin({
@@ -91,10 +92,17 @@ class TwitterLogin {
     try {
       if (Platform.isIOS) {
         /// Login to Twitter account with SFAuthenticationSession or ASWebAuthenticationSession.
-        resultURI = await authBrowser.doAuth(requestToken.authorizeURI, uri.scheme);
+        resultURI =
+            await authBrowser.doAuth(requestToken.authorizeURI, uri.scheme);
       } else if (Platform.isAndroid) {
         // Login to Twitter account with chrome_custom_tabs.
-        await authBrowser.open(requestToken.authorizeURI, uri.scheme);
+        final success =
+            await authBrowser.open(requestToken.authorizeURI, uri.scheme);
+        if (!success) {
+          throw UnsupportedError(
+            'Could not open browser, probably caused by unavailable custom tabs.',
+          );
+        }
         resultURI = await completer.future;
         subscribe.cancel();
       } else {


### PR DESCRIPTION
Thanks for great plugin.

> v4.0.0 
> remove flutter_inappwebview as a dependency.
> https://github.com/0maru/twitter_login/pull/52

I think, this is good PR because `flutter_inappwebview` has a little problem.
ex: https://github.com/pichillilorenzo/flutter_inappwebview/issues/593

But, maybe degrated when Custom Tabs is unavailable.
Caused `Failed to handle method call`, detail log is here.
<details>
<summary>Failed to handle method call</summary>

```
E/MethodChannel#twitter_login/auth_browser( 3404): Failed to handle method call
E/MethodChannel#twitter_login/auth_browser( 3404): java.lang.IllegalStateException: Reply already submitted
E/MethodChannel#twitter_login/auth_browser( 3404): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:155)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler$1.success(MethodChannel.java:238)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at com.maru.twitter_login.chrome_custom_tabs.ChromeSafariBrowserManager.open(ChromeSafariBrowserManager.java:61)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at com.maru.twitter_login.chrome_custom_tabs.ChromeSafariBrowserManager.onMethodCall(ChromeSafariBrowserManager.java:41)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:233)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:818)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at android.os.MessageQueue.next(MessageQueue.java:323)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at android.os.Looper.loop(Looper.java:135)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at android.app.ActivityThread.main(ActivityThread.java:5417)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at java.lang.reflect.Method.invoke(Native Method)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
E/MethodChannel#twitter_login/auth_browser( 3404): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
E/DartMessenger( 3404): Uncaught exception in binary message listener
E/DartMessenger( 3404): java.lang.IllegalStateException: Reply already submitted
E/DartMessenger( 3404): 	at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply(DartMessenger.java:155)
E/DartMessenger( 3404): 	at io.flutter.plugin.common.MethodChannel$IncomingMethodCallHandler.onMessage(MethodChannel.java:253)
E/DartMessenger( 3404): 	at io.flutter.embedding.engine.dart.DartMessenger.handleMessageFromDart(DartMessenger.java:85)
E/DartMessenger( 3404): 	at io.flutter.embedding.engine.FlutterJNI.handlePlatformMessage(FlutterJNI.java:818)
E/DartMessenger( 3404): 	at android.os.MessageQueue.nativePollOnce(Native Method)
E/DartMessenger( 3404): 	at android.os.MessageQueue.next(MessageQueue.java:323)
E/DartMessenger( 3404): 	at android.os.Looper.loop(Looper.java:135)
E/DartMessenger( 3404): 	at android.app.ActivityThread.main(ActivityThread.java:5417)
E/DartMessenger( 3404): 	at java.lang.reflect.Method.invoke(Native Method)
E/DartMessenger( 3404): 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
E/DartMessenger( 3404): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
I/FIAM.Display( 3404): Unbinding from activity: io.flutter.embedding.android.FlutterFragmentActivity
I/FIAM.Headless( 3404): Removing display event component
I/FIAM.Display( 3404): Binding to activity: com.maru.twitter_login.chrome_custom_tabs.ChromeCustomTabsActivity
I/FIAM.Headless( 3404): Setting display event component
```
</details>

In android device set to default browser that does not support Custom Tabs, suspends empty screen on browser.

screenshot is here↓
![Screenshot_1623672722](https://user-images.githubusercontent.com/59546923/121899084-0c7c6c00-cd5f-11eb-9b48-e646fc4ac98f.png)

I think, open browser method should return some response whether `available` or `ununavailable` for handing error.

Thanks.

