### PR TITLE
fix: replace Exception(error) to rethrow

### DIFF
--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -69,7 +69,7 @@ class User {
       );
       return User(params);
     } on Exception catch (error) {
-      throw Exception(error);
+      rethrow;
     }
   }
 }

--- a/lib/entity/user.dart
+++ b/lib/entity/user.dart
@@ -68,7 +68,7 @@ class User {
         accessTokenSecret,
       );
       return User(params);
-    } on Exception catch (error) {
+    } on Exception {
       rethrow;
     }
   }

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -54,7 +54,7 @@ Future<Map<String, dynamic>>? httpPost(
 
     return Uri.splitQueryString(res.body);
   } on Exception catch (error) {
-    throw Exception(error);
+    rethrow;
   }
 }
 
@@ -87,7 +87,7 @@ Future<Map<String, dynamic>> httpGet(
 
     return jsonDecode(res.body);
   } on Exception catch (error) {
-    throw Exception(error);
+    rethrow;
   }
 }
 

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -53,7 +53,7 @@ Future<Map<String, dynamic>>? httpPost(
     }
 
     return Uri.splitQueryString(res.body);
-  } on Exception catch (error) {
+  } on Exception {
     rethrow;
   }
 }
@@ -86,7 +86,7 @@ Future<Map<String, dynamic>> httpGet(
     }
 
     return jsonDecode(res.body);
-  } on Exception catch (error) {
+  } on Exception {
     rethrow;
   }
 }


### PR DESCRIPTION
便利なライブラリの公開ありがとうございます。

utils.dart で `HTTPException()`をthrowしていますが、自身でcatch してExceptionに丸めて throw される実装になっていたのでrethrowに変更しました。[stackTraceも上書きされない](https://stackoverflow.com/a/16028756)のでこちらの方が良さそうかと思います。
~~(元コードとの比較のしやすさの観点からrethrowに置換しましたが、catchして何もせずにrethrowしているので`try{}`なしでも同じ挙動です)~~<-すみませんこれ間違いなので無視してください。